### PR TITLE
Fix early stopping metric name

### DIFF
--- a/deeptables/models/deeptable.py
+++ b/deeptables/models/deeptable.py
@@ -644,7 +644,7 @@ class DeepTable:
         #    callbacks.append(mcp)
         #    print(f'Injected a callback [ModelCheckpoint].\nfilepath:{mcp.filepath}\nmonitor:{mcp.monitor}')
         if es is None:
-            es = EarlyStopping(monitor=self.monitor,
+            es = EarlyStopping(monitor=self.monitor.lower(),
                                restore_best_weights=True,
                                patience=self.config.earlystopping_patience,
                                verbose=1,


### PR DESCRIPTION
I was running a Binary Classification example from https://github.com/DataCanvasIO/DeepTables/blob/master/docs/source/examples.md#binary-classification

The metrics for this configuration are defined as `metrics=['AUC','accuracy']`.

When running this example on Tensorflow 2.3.1, I get the following  warning:

```
WARNING:tensorflow:Early stopping conditioned on metric `val_AUC` which is not available. Available metrics are: loss,auc,accuracy,val_loss,val_auc,val_accuracy
```

Essentially, Tensorflow expects to see `val_auc` rather than `val_AUC`. I introduce a quick hack in this pull request, which converts the metric name to lower case when the EarlyStopping callback is created, but I am not sure if this is the best option.
